### PR TITLE
Switch Docker images to Alpine for smaller image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 AS builder
+FROM mcr.microsoft.com/dotnet/sdk:8.0-alpine AS builder
 WORKDIR /sources
 COPY . .
 
-RUN apt update && apt install -y unzip
+RUN apk add --no-cache unzip
 RUN dotnet publish -c Release --output build Minerva.sln --self-contained false
 RUN unzip -qq ./tools/figuredata-shockwave.zip -d build
 RUN unzip -qq ./tools/badges.zip -d build
 
-FROM mcr.microsoft.com/dotnet/aspnet:8.0
+FROM mcr.microsoft.com/dotnet/aspnet:8.0-alpine
+RUN apk add --no-cache icu-libs fontconfig freetype
 WORKDIR /minerva
 COPY --from=builder /sources/build .
 ENTRYPOINT ["/minerva/Minerva"]


### PR DESCRIPTION
 ## Summary

  - Switch both build and runtime Docker images from Debian-based to Alpine (`sdk:8.0-alpine`, `aspnet:8.0-alpine`), significantly reducing the final image size from 231MB to 132MB.